### PR TITLE
Created Adapter pattern example

### DIFF
--- a/src/main/kotlin/refactoring_guru/adapter/example/Demo.kt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/Demo.kt
@@ -1,0 +1,40 @@
+package refactoring_guru.adapter.example
+
+import refactoring_guru.adapter.example.adapters.SquarePegAdapter
+import refactoring_guru.adapter.example.round.RoundHole
+import refactoring_guru.adapter.example.round.StandardRoundPeg
+import refactoring_guru.adapter.example.square.StandardSquarePeg
+
+/**
+ * EN: Demo class. Everything comes together here.
+ *
+ * RU: Демо-класс. Здесь всё сводится воедино.
+ */
+fun main() {
+    // EN: Round fits round, no surprise.
+    //
+    // RU: Круглое к круглому — всё работает.
+    val roundHole = RoundHole(5.0)
+    val roundPeg = StandardRoundPeg(5.0)
+    if (roundHole.fits(roundPeg)) {
+        println("Round peg r5 fits round hole r5.")
+    }
+
+    val smallSquarePeg = StandardSquarePeg(2.0)
+    val largeSquarePeg = StandardSquarePeg(20.0)
+    // EN: roundHole.fits(smallSquarePeg) // Won't compile.
+    //
+    // RU: roundHole.fits(smallSquarePeg) // Не скомпилируется.
+
+    // EN: Adapter solves the problem.
+    //
+    // RU: Адаптер решит проблему.
+    val smallSquarePegAdapter = SquarePegAdapter(smallSquarePeg)
+    val largeSquarePegAdapter = SquarePegAdapter(largeSquarePeg)
+    if (roundHole.fits(smallSquarePegAdapter)) {
+        println("Square peg w2 fits round hole r5.")
+    }
+    if (!roundHole.fits(largeSquarePegAdapter)) {
+        println("Square peg w20 does not fit into round hole r5.")
+    }
+}

--- a/src/main/kotlin/refactoring_guru/adapter/example/OutputDemo.txt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/OutputDemo.txt
@@ -1,0 +1,3 @@
+Round peg r5 fits round hole r5.
+Square peg w2 fits round hole r5.
+Square peg w20 does not fit into round hole r5.

--- a/src/main/kotlin/refactoring_guru/adapter/example/adapters/SquarePegAdapter.kt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/adapters/SquarePegAdapter.kt
@@ -1,0 +1,17 @@
+package refactoring_guru.adapter.example.adapters
+
+import refactoring_guru.adapter.example.round.RoundPeg
+import refactoring_guru.adapter.example.square.SquarePeg
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * EN: Adapter allows fitting square pegs into round holes.
+ *
+ * RU: Адаптер позволяет использовать КвадратныеКолышки и КруглыеОтверстия
+ * вместе.
+ */
+class SquarePegAdapter(peg: SquarePeg) : RoundPeg {
+
+    override val radius: Double = sqrt((peg.width / 2).pow(2) * 2)
+}

--- a/src/main/kotlin/refactoring_guru/adapter/example/round/RoundHole.kt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/round/RoundHole.kt
@@ -1,0 +1,11 @@
+package refactoring_guru.adapter.example.round
+
+/**
+ * EN: RoundHoles are compatible with RoundPegs.
+ *
+ * RU: КруглоеОтверстие совместимо с КруглымиКолышками.
+ */
+data class RoundHole(val radius: Double) {
+
+    fun fits(peg: RoundPeg) = radius >= peg.radius
+}

--- a/src/main/kotlin/refactoring_guru/adapter/example/round/RoundPeg.kt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/round/RoundPeg.kt
@@ -1,0 +1,10 @@
+package refactoring_guru.adapter.example.round
+
+/**
+ * EN: RoundPegs are compatible with RoundHoles.
+ *
+ * RU: КруглыеКолышки совместимы с КруглымиОтверстиями.
+ */
+interface RoundPeg {
+    val radius: Double
+}

--- a/src/main/kotlin/refactoring_guru/adapter/example/round/StandardRoundPeg.kt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/round/StandardRoundPeg.kt
@@ -1,0 +1,3 @@
+package refactoring_guru.adapter.example.round
+
+data class StandardRoundPeg(override val radius: Double) : RoundPeg

--- a/src/main/kotlin/refactoring_guru/adapter/example/square/SquarePeg.kt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/square/SquarePeg.kt
@@ -1,0 +1,14 @@
+package refactoring_guru.adapter.example.square
+
+/**
+ * EN: SquarePegs are not compatible with RoundHoles (they were implemented by
+ * previous development team). But we have to integrate them into our program.
+ *
+ * RU: КвадратныеКолышки несовместимы с КруглымиОтверстиями (они остались в
+ * проекте после бывших разработчиков). Но мы должны как-то интегрировать их в
+ * нашу систему.
+ */
+interface SquarePeg {
+    val width: Double
+    val square: Double
+}

--- a/src/main/kotlin/refactoring_guru/adapter/example/square/StandardSquarePeg.kt
+++ b/src/main/kotlin/refactoring_guru/adapter/example/square/StandardSquarePeg.kt
@@ -1,0 +1,8 @@
+package refactoring_guru.adapter.example.square
+
+import kotlin.math.pow
+
+data class StandardSquarePeg(override val width: Double) : SquarePeg {
+
+    override val square: Double = width.pow(2)
+}


### PR DESCRIPTION
This differs from the Java example slightly as interfaces have been used for both the round peg and square peg. This removes the need to have open classes which can be inherited from. 